### PR TITLE
Fix SBT assembly

### DIFF
--- a/sparkproject/build.sbt
+++ b/sparkproject/build.sbt
@@ -25,8 +25,8 @@ lazy val root = (project in file(".")).
     coverageHighlighting := true,
 
     libraryDependencies ++= Seq(
-      "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
-      "org.apache.spark" %% "spark-mllib" % sparkVersion % "provided",
+      "org.apache.spark" %% "spark-sql" % sparkVersion,
+      "org.apache.spark" %% "spark-mllib" % sparkVersion,
       "com.softwaremill.sttp" %% "core" % "1.5.4",
       "com.softwaremill.sttp" %% "async-http-client-backend-future" % "1.5.4",
       "com.github.marklister" %% "product-collections" % "1.4.5",
@@ -38,9 +38,7 @@ lazy val root = (project in file(".")).
       "com.trueaccord.scalapb" %% "scalapb-runtime"      % com.trueaccord.scalapb.compiler.Version.scalapbVersion % "protobuf",
       // for gRPC
       "io.grpc"                %  "grpc-netty"           % "1.4.0",
-      "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % com.trueaccord.scalapb.compiler.Version.scalapbVersion,
-      // for JSON conversion
-      "com.trueaccord.scalapb" %% "scalapb-json4s"       % "0.3.0"
+      "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % com.trueaccord.scalapb.compiler.Version.scalapbVersion
     ),
 
 

--- a/sparkproject/build.sbt
+++ b/sparkproject/build.sbt
@@ -38,7 +38,9 @@ lazy val root = (project in file(".")).
       "com.trueaccord.scalapb" %% "scalapb-runtime"      % com.trueaccord.scalapb.compiler.Version.scalapbVersion % "protobuf",
       // for gRPC
       "io.grpc"                %  "grpc-netty-shaded"           % "1.9.1",
-      "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % com.trueaccord.scalapb.compiler.Version.scalapbVersion
+      "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % com.trueaccord.scalapb.compiler.Version.scalapbVersion,
+      // Added so that we use netty 4.1.30 not trying to mix and match 2 different versions
+      "io.netty" % "netty-all" % "4.1.30.Final"
     ),
 
 
@@ -55,9 +57,22 @@ lazy val root = (project in file(".")).
       case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
       case PathList("META-INF", "native", xs @ _*) => MergeStrategy.deduplicate
       case PathList("META-INF", xs @ _ *) => MergeStrategy.discard
-      case PathList("javax", "servlet", xs @ _*) => MergeStrategy.first
-      case PathList("org", "apache", xs @ _*) => MergeStrategy.first
-      case PathList("org", "jboss", xs @ _*) => MergeStrategy.first
+      case PathList("javax", "servlet", xs @ _*) => MergeStrategy.last
+      case PathList("org", "apache", xs @ _*) => MergeStrategy.last
+      case PathList("org", "jboss", xs @ _*) => MergeStrategy.last
+        // Start http://queirozf.com/entries/creating-scala-fat-jars-for-spark-on-sbt-with-sbt-assembly-plugin
+      case PathList("org","aopalliance", xs @ _*) => MergeStrategy.last
+      case PathList("javax", "inject", xs @ _*) => MergeStrategy.last
+      case PathList("javax", "servlet", xs @ _*) => MergeStrategy.last
+      case PathList("javax", "activation", xs @ _*) => MergeStrategy.last
+      case PathList("org", "apache", xs @ _*) => MergeStrategy.last
+      case PathList("com", "google", xs @ _*) => MergeStrategy.last
+      case PathList("com", "esotericsoftware", xs @ _*) => MergeStrategy.last
+      case PathList("com", "codahale", xs @ _*) => MergeStrategy.last
+      case PathList("com", "yammer", xs @ _*) => MergeStrategy.last
+        // End http://queirozf.com/entries/creating-scala-fat-jars-for-spark-on-sbt-with-sbt-assembly-plugin
+      case PathList("com", "sun", "activation", "registries", xs @ _*) => MergeStrategy.last
+      case PathList("com", "sun", "activation", "viewers", xs @ _*) => MergeStrategy.last
       case "about.html"  => MergeStrategy.rename
       case "reference.conf" => MergeStrategy.concat
       case m =>

--- a/sparkproject/build.sbt
+++ b/sparkproject/build.sbt
@@ -11,7 +11,7 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.holdenkarau.predict.pr.comments",
-      scalaVersion := "2.11.8"
+      scalaVersion := "2.11.12"
     )),
     name := "sparkProject",
     version := "0.0.1",
@@ -37,7 +37,7 @@ lazy val root = (project in file(".")).
 
       "com.trueaccord.scalapb" %% "scalapb-runtime"      % com.trueaccord.scalapb.compiler.Version.scalapbVersion % "protobuf",
       // for gRPC
-      "io.grpc"                %  "grpc-netty"           % "1.4.0",
+      "io.grpc"                %  "grpc-netty-shaded"           % "1.9.1",
       "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % com.trueaccord.scalapb.compiler.Version.scalapbVersion
     ),
 
@@ -50,6 +50,7 @@ lazy val root = (project in file(".")).
     mergeStrategy in assembly := {
       case m if m.toLowerCase.endsWith("manifest.mf") => MergeStrategy.discard
       case m if m.toLowerCase.endsWith("io.netty.versions.properties") => MergeStrategy.first
+      case m if m.toLowerCase.endsWith("git.properties") => MergeStrategy.discard
         // Travis is giving a weird error on netty I don't see locally :(
       case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
       case PathList("META-INF", "native", xs @ _*) => MergeStrategy.deduplicate


### PR DESCRIPTION
rip out scalapb-json4s because it's was bringing in another version of jackson and we don't need it, make spark-sql and mllib no longer provided because we're going to run in a standalone container.